### PR TITLE
Brief2selfreport

### DIFF
--- a/flourish_metadata_rules/metadata_rules/child_rule_groups/child_visit_rules.py
+++ b/flourish_metadata_rules/metadata_rules/child_rule_groups/child_visit_rules.py
@@ -56,8 +56,15 @@ class ChildVisitRuleGroup(CrfRuleGroup):
         consequence=REQUIRED,
         alternative=NOT_REQUIRED,
         target_models=[f'{app_label}.childphqdepressionscreening',
-                       f'{app_label}.childgadanxietyscreening',
-                       f'{app_label}.brief2selfreported', ])
+                       f'{app_label}.childgadanxietyscreening', ])
+    
+    older_than_11 = CrfRule(
+        predicate=pc.func_11_years_older,
+        consequence=REQUIRED,
+        alternative=NOT_REQUIRED,
+        target_models=[f'{app_label}.brief2selfreported', ])
+
+
 
     younger_than_36months = CrfRule(
         predicate=pc.func_36_months_younger,

--- a/flourish_metadata_rules/predicates/child_predicates.py
+++ b/flourish_metadata_rules/predicates/child_predicates.py
@@ -255,6 +255,12 @@ class ChildPredicates(PredicateCollection):
         """
         child_age = self.get_child_age(visit=visit)
         return child_age.years >= 12 if child_age else False
+    
+    def func_11_years_older(self, visit=None, **kwargs):
+        """Returns true if participant is 11 years or older
+        """
+        child_age = self.get_child_age(visit=visit)
+        return child_age.years >= 11 if child_age else False
 
     def func_12_years_older_female(self, visit=None, **kwargs):
         """Returns true if participant is 12 years or older

--- a/flourish_metadata_rules/tests/test_child_predicates.py
+++ b/flourish_metadata_rules/tests/test_child_predicates.py
@@ -86,7 +86,7 @@ class TestChildPredicates(SiteTestCaseMixin, TestCase):
 
         self.assertTrue(
             self.pc.func_12_years_older(self.infant_visits[0], ))
-    @tag('yes')   
+          
     def test_func_11_years_older(self):
         ChildAssent.objects.create(
             subject_identifier=self.subject_identifier,

--- a/flourish_metadata_rules/tests/test_child_predicates.py
+++ b/flourish_metadata_rules/tests/test_child_predicates.py
@@ -86,6 +86,18 @@ class TestChildPredicates(SiteTestCaseMixin, TestCase):
 
         self.assertTrue(
             self.pc.func_12_years_older(self.infant_visits[0], ))
+    @tag('yes')   
+    def test_func_11_years_older(self):
+        ChildAssent.objects.create(
+            subject_identifier=self.subject_identifier,
+            gender='M')
+
+        CaregiverChildConsent.objects.create(
+            subject_identifier=self.subject_identifier,
+            child_dob=(get_utcnow() - relativedelta(years=11, months=5)).date())
+
+        self.assertTrue(
+            self.pc.func_11_years_older(self.infant_visits[0], ))
 
     def test_func_12_years_older_female(self):
         ChildAssent.objects.create(


### PR DESCRIPTION
Created a Crf rule in the ChildVisitRuleGroup which makes brief2selfreport required if a child is 11 years and older ,updated the predictes and tested the newly made predicate