### PR TITLE
:sparkles: feature (Anc Second Screening): Implemented multi-child su…

### DIFF
--- a/flourish_metadata_rules/predicates/caregiver_predicates.py
+++ b/flourish_metadata_rules/predicates/caregiver_predicates.py
@@ -71,13 +71,15 @@ class CaregiverPredicates(PredicateCollection):
             return True
 
     def currently_pregnant(self, visit=None, **kwargs):
+        child_subject_identifier = self.get_child_subject_identifier_by_visit(visit)
 
         if self.enrolled_pregnant(visit=visit, **kwargs):
             maternal_delivery_cls = django_apps.get_model(
                 f'{self.app_label}.maternaldelivery')
             try:
                 maternal_delivery_cls.objects.get(
-                    subject_identifier=visit.subject_identifier)
+                    subject_identifier=visit.subject_identifier,
+                    child_subject_identifier=child_subject_identifier)
             except maternal_delivery_cls.DoesNotExist:
                 return True
         return False

--- a/flourish_metadata_rules/predicates/child_predicates.py
+++ b/flourish_metadata_rules/predicates/child_predicates.py
@@ -202,6 +202,7 @@ class ChildPredicates(PredicateCollection):
 
         try:
             maternal_delivery_cls.objects.get(
+                child_subject_identifier=visit.subject_identifier,
                 subject_identifier=maternal_subject_id,
                 live_infants_to_register__gte=1)
         except maternal_delivery_cls.DoesNotExist:
@@ -565,6 +566,7 @@ class ChildPredicates(PredicateCollection):
             subject_identifier=visit.subject_identifier)
         try:
             enrollment_model.objects.get(
+                child_subject_identifier=visit.subject_identifier,
                 subject_identifier=maternal_subject_id)
         except enrollment_model.DoesNotExist:
             return False


### PR DESCRIPTION
…pport for ANC enrolledCaregiver

This commit addresses various changes to support the inclusion of multiple children to one caregiver in the Flourish Caregiver project. Child subject identifiers were added to antenatal screenings, ultra sounds, maternal deliveries and enrollment forms. The dashboard was updated to reflect the multi-child support. The addition of child subject identifiers aids in improving the tracking process, especially when handling multi-child scenarios. Lastly, print statements were removed for a cleaner codebase.