### PR TITLE
fix(Rules): Add new predicates for infant HIV testing



### DIFF
--- a/flourish_metadata_rules/metadata_rules/child_rule_groups/infant_hiv_test_rules.py
+++ b/flourish_metadata_rules/metadata_rules/child_rule_groups/infant_hiv_test_rules.py
@@ -1,7 +1,8 @@
-from ...predicates import ChildPredicates
-
+from edc_metadata import NOT_REQUIRED, REQUIRED
 from edc_metadata import NOT_REQUIRED, REQUIRED
 from edc_metadata_rules import CrfRule, CrfRuleGroup, register
+
+from ...predicates import ChildPredicates
 
 app_label = 'flourish_child'
 pc = ChildPredicates()
@@ -9,12 +10,42 @@ pc = ChildPredicates()
 
 @register()
 class InfantHIVTestRuleGroup(CrfRuleGroup):
-    infant_hiv_testing = CrfRule(
-        predicate=pc.func_hiv_infant_testing,
+    birth_hiv_testing = CrfRule(
+        predicate=pc.hiv_test_birth_required,
         consequence=REQUIRED,
         alternative=NOT_REQUIRED,
-        target_models=[f'{app_label}.infanthivtesting', ])
+        target_models=[f'{app_label}.infanthivtestingbirth', ])
+
+    other_hiv_testing = CrfRule(
+        predicate=pc.hiv_test_other_required,
+        consequence=REQUIRED,
+        alternative=NOT_REQUIRED,
+        target_models=[f'{app_label}.infanthivtestingother', ])
+
+    hiv_testing_18months = CrfRule(
+        predicate=pc.hiv_test_18_months_required,
+        consequence=REQUIRED,
+        alternative=NOT_REQUIRED,
+        target_models=[f'{app_label}.infanthivtesting18months', ])
+
+    hiv_testing_afr_brestfeeding = CrfRule(
+        predicate=pc.hiv_test_after_breastfeeding_required,
+        consequence=REQUIRED,
+        alternative=NOT_REQUIRED,
+        target_models=[f'{app_label}.infanthivtestingafterbreastfeeding', ])
+
+    hiv_testing_6to8_months = CrfRule(
+        predicate=pc.hiv_test_6_to_8_weeks_required,
+        consequence=REQUIRED,
+        alternative=NOT_REQUIRED,
+        target_models=[f'{app_label}.infanthivtestingage6to8weeks', ])
+
+    hiv_testing_9months = CrfRule(
+        predicate=pc.hiv_test_9_months_required,
+        consequence=REQUIRED,
+        alternative=NOT_REQUIRED,
+        target_models=[f'{app_label}.infanthivtesting9months', ])
 
     class Meta:
         app_label = app_label
-    
+        source_model = f'{app_label}.infanthivtesting'

--- a/flourish_metadata_rules/predicates/child_predicates.py
+++ b/flourish_metadata_rules/predicates/child_predicates.py
@@ -4,7 +4,7 @@ from dateutil.relativedelta import relativedelta
 from django.apps import apps as django_apps
 from django.db.models import Q
 from edc_base.utils import age, get_utcnow
-from edc_constants.constants import FEMALE, IND, NO, PENDING, POS, YES
+from edc_constants.constants import FEMALE, IND, NO, PENDING, POS, YES, OTHER
 from edc_metadata_rules import PredicateCollection
 from edc_reference.models import Reference
 
@@ -704,3 +704,66 @@ class ChildPredicates(PredicateCollection):
                  'skin_test_results']
         return any([getattr(latest_obj, field, None) == PENDING
                     for field in tests]) if latest_obj else True
+
+    def hiv_test_birth_required(self, visit=None, **kwargs):
+        try:
+            infant_hiv_testing = self.infant_hiv_test_model_cls.objects.get(
+                child_visit=visit)
+        except self.infant_hiv_test_model_cls.DoesNotExist:
+            return False
+        else:
+            return True if 'birth' in [i.short_name for i in
+                                       infant_hiv_testing.test_visit.all()] else False
+
+    def hiv_test_other_required(self, visit=None, **kwargs):
+        try:
+            infant_hiv_testing = self.infant_hiv_test_model_cls.objects.get(
+                child_visit=visit)
+        except self.infant_hiv_test_model_cls.DoesNotExist:
+            return False
+        else:
+            return True if OTHER in [i.short_name for i in
+                                     infant_hiv_testing.test_visit.all()] else False
+
+    def hiv_test_18_months_required(self, visit=None, **kwargs):
+        try:
+            infant_hiv_testing = self.infant_hiv_test_model_cls.objects.get(
+                child_visit=visit)
+        except self.infant_hiv_test_model_cls.DoesNotExist:
+            return False
+        else:
+            return True if '18_months' in [i.short_name for i in
+                                           infant_hiv_testing.test_visit.all()] else False
+
+    def hiv_test_after_breastfeeding_required(self, visit=None, **kwargs):
+        try:
+            infant_hiv_testing = self.infant_hiv_test_model_cls.objects.get(
+                child_visit=visit)
+        except self.infant_hiv_test_model_cls.DoesNotExist:
+            return False
+        else:
+            return True if 'after_breastfeeding' in [i.short_name for i in
+                                                     infant_hiv_testing.test_visit.all(
+
+                                                     )] else False
+
+    def hiv_test_6_to_8_weeks_required(self, visit=None, **kwargs):
+        try:
+            infant_hiv_testing = self.infant_hiv_test_model_cls.objects.get(
+                child_visit=visit)
+        except self.infant_hiv_test_model_cls.DoesNotExist:
+            return False
+        else:
+            return True if '6_to_8_weeks' in [i.short_name for i in
+                                              infant_hiv_testing.test_visit.all()] else \
+                False
+
+    def hiv_test_9_months_required(self, visit=None, **kwargs):
+        try:
+            infant_hiv_testing = self.infant_hiv_test_model_cls.objects.get(
+                child_visit=visit)
+        except self.infant_hiv_test_model_cls.DoesNotExist:
+            return False
+        else:
+            return True if '9_months' in [i.short_name for i in
+                                          infant_hiv_testing.test_visit.all()] else False


### PR DESCRIPTION
Expanded 'child_predicates.py' to include functions that check if various HIV tests at different stages are required. Additionally, updated 'infant_hiv_test_rules.py' with rules that use these new predicates. This provides more granular control over which HIV tests are required based on individual requirements.