### PR TITLE
Simplify 4th annual quarterly call check


### DIFF
--- a/flourish_metadata_rules/predicates/child_predicates.py
+++ b/flourish_metadata_rules/predicates/child_predicates.py
@@ -391,25 +391,7 @@ class ChildPredicates(PredicateCollection):
         """
         Returns true if the visit is the 4th annual quarterly call
         """
-        child_age = self.get_child_age(visit=visit)
-
-        caregiver_child_consent_cls = django_apps.get_model(
-            f'{self.maternal_app_label}.caregiverchildconsent')
-
-        consents = caregiver_child_consent_cls.objects.filter(
-            subject_identifier=visit.subject_identifier)
-
-        if child_age.years >= 3 and consents:
-
-            caregiver_child_consent = consents.latest('consent_datetime')
-
-            child_is_three_at_date = caregiver_child_consent.child_dob + relativedelta(
-                years=3, months=0)
-
-            if visit.report_datetime.date() >= child_is_three_at_date:
-                return int(visit.visit_code[:4]) % 4 == 0
-
-        return False
+        return int(visit.visit_code[:4]) % 4 == 0
 
     def func_2000D(self, visit, **kwargs):
         """


### PR DESCRIPTION

Removed unnecessary checks related to age and consents in the 4th annual quarterly call check function. Now, it directly checks whether the visit code is divisible by 4, simplifying the operation and increasing the efficiency of the function.