### PR TITLE
(refactor): Remove child and caregiver TB screening rules



### DIFF
--- a/flourish_metadata_rules/metadata_rules/caregiver_rule_groups/subject_visit_rules.py
+++ b/flourish_metadata_rules/metadata_rules/caregiver_rule_groups/subject_visit_rules.py
@@ -1,6 +1,6 @@
-from edc_metadata import NOT_REQUIRED, REQUIRED
-from edc_metadata_rules import CrfRule, CrfRuleGroup, register, P
 from edc_constants.constants import PARTICIPANT
+from edc_metadata import NOT_REQUIRED, REQUIRED
+from edc_metadata_rules import CrfRule, CrfRuleGroup, P, register
 
 from ...predicates import CaregiverPredicates
 
@@ -10,7 +10,6 @@ pc = CaregiverPredicates()
 
 @register()
 class MaternalVisitRuleGroup(CrfRuleGroup):
-
     clinician_notes = CrfRule(
         predicate=P('info_source', 'eq', PARTICIPANT),
         consequence=REQUIRED,
@@ -134,12 +133,6 @@ class MaternalVisitRuleGroup(CrfRuleGroup):
         alternative=NOT_REQUIRED,
         target_models=[f'{app_label}.maternalarvadherence']
     )
-
-    caregiver_tb_screening = CrfRule(
-        predicate=pc.func_caregiver_tb_screening,
-        consequence=REQUIRED,
-        alternative=NOT_REQUIRED,
-        target_models=[f'{app_label}.caregivertbscreening', ])
 
     caregiver_tb_referral_outcome = CrfRule(
         predicate=pc.func_caregiver_tb_referral_outcome,

--- a/flourish_metadata_rules/metadata_rules/child_rule_groups/child_visit_rules.py
+++ b/flourish_metadata_rules/metadata_rules/child_rule_groups/child_visit_rules.py
@@ -130,13 +130,6 @@ class ChildVisitRuleGroup(CrfRuleGroup):
         target_models=[f'{app_label}.tblabresultsadol', ]
     )
 
-    child_tb_screening = CrfRule(
-        predicate=pc.func_child_tb_screening_required,
-        consequence=REQUIRED,
-        alternative=NOT_REQUIRED,
-        target_models=[f'{app_label}.childtbscreening', ]
-    )
-
     child_tb_referral_outcome = CrfRule(
         predicate=pc.func_child_tb_referral_outcome,
         consequence=REQUIRED,


### PR DESCRIPTION
Removed the Child and Caregiver TB screening rules from metadata rules. This step was taken because the aforementioned rules were no longer in use thereby cleaning up the codebase. Also, minor reformatting and ordering of imports was performed where needed. Signed-off-by: nmunatsibw 