### PR TITLE
(refactor): Improve HIV test requirements evaluation


### DIFF
--- a/flourish_metadata_rules/predicates/child_predicates.py
+++ b/flourish_metadata_rules/predicates/child_predicates.py
@@ -2,7 +2,6 @@ from datetime import timedelta
 
 from django.apps import apps as django_apps
 from django.db.models import Q
-from edc_appointment.constants import UNSCHEDULED_APPT
 from edc_base.utils import age, get_utcnow
 from edc_constants.constants import FEMALE, IND, NO, OTHER, PENDING, POS, UNKNOWN, YES
 from edc_metadata_rules import PredicateCollection
@@ -612,10 +611,11 @@ class ChildPredicates(PredicateCollection):
 
     def func_restults_on_unscheduel(self, visit, model):
         model_cls = django_apps.get_model(model)
-        if visit.appointment.appt_reason == UNSCHEDULED_APPT:
-
-            previous_appt = self.get_previous_appt_instance(visit.appointment)
-
+        if visit.appointment.visit_code_sequence > 0:
+            previous_appt = visit.appointment.__class__.objects.get(
+                subject_identifier=visit.appointment.subject_identifier,
+                visit_code=visit.visit_code,
+                visit_code_sequence=visit.appointment.visit_code_sequence - 1)
             try:
                 prev_obj = model_cls.objects.get(child_visit__appointment=previous_appt)
             except model_cls.DoesNotExist:

--- a/flourish_metadata_rules/predicates/child_predicates.py
+++ b/flourish_metadata_rules/predicates/child_predicates.py
@@ -609,7 +609,7 @@ class ChildPredicates(PredicateCollection):
             return child_age in [i.short_name for i in
                                  infant_hiv_testing.test_visit.all()]
 
-    def func_restults_on_unscheduel(self, visit, model):
+    def func_results_on_unscheduled(self, visit, model):
         model_cls = django_apps.get_model(model)
         if visit.appointment.visit_code_sequence > 0:
             previous_appt = visit.appointment.__class__.objects.get(

--- a/flourish_metadata_rules/predicates/child_predicates.py
+++ b/flourish_metadata_rules/predicates/child_predicates.py
@@ -629,32 +629,32 @@ class ChildPredicates(PredicateCollection):
     def hiv_test_birth_required(self, visit=None, **kwargs):
         model = 'flourish_child.infanthivtestingbirth'
         return (self.hiv_test_required('birth', visit) or
-                self.func_restults_on_unscheduel(model=model, visit=visit))
+                self.func_results_on_unscheduled(model=model, visit=visit))
 
     def hiv_test_other_required(self, visit=None, **kwargs):
         model = 'flourish_child.infanthivtestingother'
         return (self.hiv_test_required(OTHER, visit) or
-                self.func_restults_on_unscheduel(model=model, visit=visit))
+                self.func_results_on_unscheduled(model=model, visit=visit))
 
     def hiv_test_18_months_required(self, visit=None, **kwargs):
         model = 'flourish_child.infanthivtesting18months'
         return (self.hiv_test_required('18_months', visit) or
-                self.func_restults_on_unscheduel(model=model, visit=visit))
+                self.func_results_on_unscheduled(model=model, visit=visit))
 
     def hiv_test_after_breastfeeding_required(self, visit=None, **kwargs):
         model = 'flourish_child.infanthivtestingafterbreastfeeding'
         return (self.hiv_test_required('after_breastfeeding', visit) or
-                self.func_restults_on_unscheduel(model=model, visit=visit))
+                self.func_results_on_unscheduled(model=model, visit=visit))
 
     def hiv_test_6_to_8_weeks_required(self, visit=None, **kwargs):
         model = 'flourish_child.infanthivtestingage6to8weeks'
         return (self.hiv_test_required('6_to_8_weeks', visit) or
-                self.func_restults_on_unscheduel(model=model, visit=visit))
+                self.func_results_on_unscheduled(model=model, visit=visit))
 
     def hiv_test_9_months_required(self, visit=None, **kwargs):
         model = 'flourish_child.infanthivtestingage6to8weeks'
         return (self.hiv_test_required('9_months', visit) or
-                self.func_restults_on_unscheduel(model=model, visit=visit))
+                self.func_results_on_unscheduled(model=model, visit=visit))
 
     def func_child_tb_referral_outcome(self, visit=None, **kwargs):
         """Returns true if caregiver TB referral outcome crf is required


### PR DESCRIPTION
This update includes the addition of a function to check results on unscheduled appointments. This will enhance the HIV test requirements checking mechanism in the 'flourish_metadata_rules' application. This ensures that the HIV tests needed for infants are properly evaluated especially in the case of unscheduled appointments. New constants are also added to handle more diverse results. Signed-off-by: nmunatsibw 