### PR TITLE
(feature): Add childhood lead exposure risk rule function



### DIFF
--- a/flourish_metadata_rules/metadata_rules/child_rule_groups/child_visit_rules.py
+++ b/flourish_metadata_rules/metadata_rules/child_rule_groups/child_visit_rules.py
@@ -149,6 +149,13 @@ class ChildVisitRuleGroup(CrfRuleGroup):
         alternative=NOT_REQUIRED,
         target_models=[f'{app_label}.childsafistigma', ])
 
+    childhood_lead_exposure_risk = CrfRule(
+        predicate=pc.func_childhood_lead_exposure_risk_required,
+        consequence=REQUIRED,
+        alternative=NOT_REQUIRED,
+        target_models=[f'{app_label}.childhoodleadexposurerisk', ]
+    )
+
     class Meta:
         app_label = app_label
         source_model = f'{app_label}.childvisit'

--- a/flourish_metadata_rules/predicates/child_predicates.py
+++ b/flourish_metadata_rules/predicates/child_predicates.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+import pytz
 from django.apps import apps as django_apps
 from django.db.models import Q
 from edc_base.utils import age, get_utcnow
@@ -732,7 +733,11 @@ class ChildPredicates(PredicateCollection):
         is_follow_up = '_fu_' in visit.schedule_name
 
         if prev_instance:
-            return (visit.appointment.appt_datetime -
-                    prev_instance.report_datetime) > timedelta(days=365)
+            visit_definition = visit.appointment.visits.get(visit.appointment.visit_code)
+            earlist_appt_date = (visit.appointment.timepoint_datetime -
+                                 visit_definition.rlower).astimezone(
+                pytz.timezone('Africa/Gaborone'))
+            return (earlist_appt_date - prev_instance.report_datetime) > timedelta(
+                days=365)
         else:
             return is_follow_up

--- a/flourish_metadata_rules/predicates/child_predicates.py
+++ b/flourish_metadata_rules/predicates/child_predicates.py
@@ -730,4 +730,9 @@ class ChildPredicates(PredicateCollection):
         prev_instance = self.previous_model(visit=visit,
                                             model=childhood_lead_exposure_risk_model)
         is_follow_up = '_fu_' in visit.schedule_name
-        return True if not prev_instance and is_follow_up else False
+
+        if prev_instance:
+            return (visit.appointment.appt_datetime -
+                    prev_instance.report_datetime) > timedelta(days=365)
+        else:
+            return is_follow_up

--- a/flourish_metadata_rules/predicates/child_predicates.py
+++ b/flourish_metadata_rules/predicates/child_predicates.py
@@ -695,3 +695,10 @@ class ChildPredicates(PredicateCollection):
 
             )
         return False
+
+    def func_childhood_lead_exposure_risk_required(self, visit=None, **kwargs):
+        childhood_lead_exposure_risk_model = f'{self.app_label}.childhoodleadexposurerisk'
+        prev_instance = self.previous_model(visit=visit,
+                                            model=childhood_lead_exposure_risk_model)
+        is_follow_up = '_fu_' in visit.schedule_name
+        return True if not prev_instance and is_follow_up else False

--- a/flourish_metadata_rules/predicates/child_predicates.py
+++ b/flourish_metadata_rules/predicates/child_predicates.py
@@ -730,7 +730,7 @@ class ChildPredicates(PredicateCollection):
         childhood_lead_exposure_risk_model = f'{self.app_label}.childhoodleadexposurerisk'
         prev_instance = self.previous_model(visit=visit,
                                             model=childhood_lead_exposure_risk_model)
-        is_follow_up = '_fu_' in visit.schedule_name
+        is_follow_up = '300' in visit.visit_code
 
         if prev_instance:
             visit_definition = visit.appointment.visits.get(visit.appointment.visit_code)


### PR DESCRIPTION
This update includes the addition of a rule function 'func_childhood_lead_exposure_risk_required' to the child_predicates.py file and a 'childhood_lead_exposure_risk' rule to the child_visit_rules.py file. The function checks if there's a need for a childhood lead exposure risk assessment during follow-up visits, and the rule enforces this condition. Signed-off-by: nmunatsibw 