### PR TITLE
(refactor): Update model in hiv_test_9_months_required function



### DIFF
--- a/flourish_metadata_rules/predicates/child_predicates.py
+++ b/flourish_metadata_rules/predicates/child_predicates.py
@@ -653,7 +653,7 @@ class ChildPredicates(PredicateCollection):
                 self.func_results_on_unscheduled(model=model, visit=visit))
 
     def hiv_test_9_months_required(self, visit=None, **kwargs):
-        model = 'flourish_child.infanthivtestingage6to8weeks'
+        model = 'flourish_child.infanthivtesting9months'
         return (self.hiv_test_required('9_months', visit) or
                 self.func_results_on_unscheduled(model=model, visit=visit))
 


### PR DESCRIPTION
The `hiv_test_9_months_required` method in `child_predicates.py` was previously referencing the incorrect model. The model has been updated from 'flourish_child.infanthivtestingage6to8weeks' to 'flourish_child.infanthivtesting9months'. This change ensures that the HIV test at 9 months utilises the correct model. Signed-off-by: nmunatsibw 