### PR TITLE
(Feature): Add regex import in caregiver predicates module

### DIFF
--- a/flourish_metadata_rules/predicates/caregiver_predicates.py
+++ b/flourish_metadata_rules/predicates/caregiver_predicates.py
@@ -1,3 +1,4 @@
+import re
 from datetime import date
 
 from dateutil import relativedelta


### PR DESCRIPTION
A regular expressions (re) module has been imported into caregiver_predicates.py file. This module is commonly used for string manipulation and will help enrich the functionality of the caregiver predicates.