### PR TITLE
(fix): Update model reference in subject visit rules

### DIFF
--- a/flourish_metadata_rules/metadata_rules/caregiver_rule_groups/subject_visit_rules.py
+++ b/flourish_metadata_rules/metadata_rules/caregiver_rule_groups/subject_visit_rules.py
@@ -154,7 +154,7 @@ class MaternalVisitRuleGroup(CrfRuleGroup):
         predicate=pc.func_gt10_and_after_a_year,
         consequence=REQUIRED,
         alternative=NOT_REQUIRED,
-        target_models=[f'{app_label}.parentadolrelationshipscale', ])
+        target_models=[f'{app_label}.parentadolreloscaleparentmodel', ])
 
     childhood_lead_exposure_risk = CrfRule(
         predicate=pc.func_childhood_lead_exposure_risk_required,

--- a/flourish_metadata_rules/predicates/caregiver_predicates.py
+++ b/flourish_metadata_rules/predicates/caregiver_predicates.py
@@ -140,7 +140,7 @@ class CaregiverPredicates(PredicateCollection):
     def func_gt10_and_after_a_year(self, visit, **kwargs):
         # return child_age.years >= 10 if child_age else False
         relationship_scale_cls = django_apps.get_model(
-            'flourish_caregiver.parentadolrelationshipscale')
+            'flourish_caregiver.parentadolreloscaleparentmodel')
         is_gte_10 = self.func_child_age_gte10(visit, **kwargs)
 
         relationship_scale_objs = relationship_scale_cls.objects.filter(


### PR DESCRIPTION
The model reference for 'parentadolrelationshipscale' was corrected to 'parentadolreloscaleparentmodel' in both subject_visit_rules.py and caregiver_predicates.py. This ensures the correct model is being used in the rules and predicates. Signed-off-by: nmunatsibw 