### PR TITLE
Check for unscheduled reason before rendering tb screening in visit

### DIFF
--- a/flourish_metadata_rules/predicates/caregiver_predicates.py
+++ b/flourish_metadata_rules/predicates/caregiver_predicates.py
@@ -7,7 +7,7 @@ from edc_base.utils import age, get_utcnow
 from edc_constants.constants import IND, NEG, POS, UNK, YES
 from edc_metadata_rules import PredicateCollection
 from edc_reference.models import Reference
-
+from edc_visit_tracking.constants import UNSCHEDULED
 from flourish_caregiver.constants import BREASTFEED_ONLY
 from flourish_caregiver.helper_classes import MaternalStatusHelper
 from flourish_caregiver.helper_classes.utils import (
@@ -582,6 +582,9 @@ class CaregiverPredicates(PredicateCollection):
     def func_caregiver_tb_referral_outcome(self, visit=None, **kwargs):
         """Returns true if caregiver TB referral outcome crf is required
         """
+        if visit.reason == UNSCHEDULED:
+            return False
+
         caregiver_referral_model_cls = django_apps.get_model(
             f'{self.app_label}.tbreferralcaregiver')
         caregiver_referral_outcoume_cls = django_apps.get_model(
@@ -631,7 +634,7 @@ class CaregiverPredicates(PredicateCollection):
             maternal_visit__visit_code_sequence=0, )
         if unscheduled:
             return (prev_instance.count() > 0
-                    and prev_instance[0].symptomatic)
+                    and prev_instance[0].symptomatic and 'tb' in (visit.reason_unscheduled or None).casefold())
         else:
             return True
 

--- a/flourish_metadata_rules/predicates/caregiver_predicates.py
+++ b/flourish_metadata_rules/predicates/caregiver_predicates.py
@@ -634,7 +634,7 @@ class CaregiverPredicates(PredicateCollection):
             maternal_visit__visit_code_sequence=0, )
         if unscheduled:
             return (prev_instance.count() > 0
-                    and prev_instance[0].symptomatic and 'tb' in (visit.reason_unscheduled or None).casefold())
+                    and prev_instance[0].symptomatic and visit.reason_unscheduled == '2_weeks_tb_sec_screening')
         else:
             return True
 

--- a/flourish_metadata_rules/predicates/child_predicates.py
+++ b/flourish_metadata_rules/predicates/child_predicates.py
@@ -6,7 +6,7 @@ from edc_base.utils import age, get_utcnow
 from edc_constants.constants import FEMALE, IND, NO, OTHER, PENDING, POS, UNKNOWN, YES
 from edc_metadata_rules import PredicateCollection
 from edc_reference.models import Reference
-
+from edc_visit_tracking.constants import UNSCHEDULED
 from flourish_caregiver.helper_classes import MaternalStatusHelper
 from flourish_child.helper_classes.utils import child_utils
 
@@ -685,6 +685,8 @@ class ChildPredicates(PredicateCollection):
     def func_child_tb_referral_outcome(self, visit=None, **kwargs):
         """Returns true if caregiver TB referral outcome crf is required
         """
+        if visit.reason == UNSCHEDULED:
+            return False
         try:
             prev_referral = Reference.objects.filter(
                 model=f'{self.app_label}.childtbreferral',
@@ -727,7 +729,7 @@ class ChildPredicates(PredicateCollection):
             child_visit__visit_code_sequence=0, )
         if unscheduled:
             return (prev_instance.count() > 0
-                    and prev_instance[0].symptomatic)
+                    and prev_instance[0].symptomatic and visit.reason_unscheduled == '2_weeks_tb_sec_screening')
         else:
             return True
 


### PR DESCRIPTION
Check for unscheduled reason before rendering tb screening in visit and only show outcomes form in quarterly calls not in unscheduled visits